### PR TITLE
訂正版：ニックネームは６文字まで

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,7 +6,7 @@
 
   <div class="field">
   <%= f.label :nickname %><em>(6 characters maximum)</em><br />
-  <%= f.text.field :nickname, autofocus: true, maxlength: "6" %>
+  <%= f.text_field :nickname, autofocus: true, maxlength: "6" %>
   </div>
 
   <div class="field">


### PR DESCRIPTION
訂正版：ニックネームは６文字まで
（タグ の修正→９行目<%= f.text_field :nickname... %>
）
