### PR TITLE
投稿画面でのname欄を削除

### DIFF
--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -1,9 +1,10 @@
 <div class="contents row">
   <%= form_tag('/tweets', method: :post) do %>
-    <h3>投稿する</h3>
-    <input placeholder="Nickname" type="text" name="name">
-    <input placeholder="Image Url" type="text" name="image">
-    <textarea cols="30" name="text" placeholder="text" rows="10"></textarea>
+    <h3>
+    投稿する
+    </h3>
+    <input placeholder="Image URL" type="text" name="image" autofocus="true">
+    <textarea placeholder="text" name="text" cols="30" rows="10"></textarea>
     <input type="submit" value"SENT">
   <% end %>
 </div>


### PR DESCRIPTION
アソシエーションを用いたことで、投稿した時にニックネームが自動的に表示されるようになったため。
