### PR TITLE
Tweet投稿時のニックネーム欄非表示処理（コントローラー側）

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -10,12 +10,12 @@ class TweetsController < ApplicationController
   end
 
   def create
-    Tweet.create(name: tweet_params[:name], image: tweet_params[:image], text: tweet_params[:text], user_id: current_user.id)
+    Tweet.create(image: tweet_params[:image], text: tweet_params[:text], user_id: current_user.id)
   end
 
   private
   def tweet_params
-    params.permit(:name, :image, :text)
+    params.permit(:image, :text)
   end
 
   def move_to_index


### PR DESCRIPTION
ニックネームは投稿時に、自動的に表示されるようになったため。
