### PR TITLE
Tweetsテーブルからname欄を削除した

### DIFF
--- a/db/migrate/20161027105507_remove_name_form_tweets.rb
+++ b/db/migrate/20161027105507_remove_name_form_tweets.rb
@@ -1,0 +1,4 @@
+class RemoveNameFormTweets < ActiveRecord::Migration
+  def change
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161027075001) do
+ActiveRecord::Schema.define(version: 20161027105507) do
 
   create_table "tweets", force: :cascade do |t|
     t.string   "name",       limit: 255


### PR DESCRIPTION
Tweetsテーブルに、nameの情報を保存させる必要がなくなったため
